### PR TITLE
Globe: Earth–sun lighting, frame docs, satellite ground track

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -336,6 +336,7 @@ function App() {
               socket={socket}
               session={session}
               entities={worldEntities}
+              simTiming={simTiming}
               selectedEntityId={mapSelectedEntityId}
               onSelectedEntityIdChange={setMapSelectedEntityId}
             />

--- a/client/src/components/MapView.jsx
+++ b/client/src/components/MapView.jsx
@@ -160,6 +160,8 @@ const MapView = ({
   socket,
   session,
   entities = [],
+  /** Server exercise clock; drives Cesium sun/lighting so the globe shows diurnal rotation vs the sun. */
+  simTiming = null,
   selectedEntityId: selectedEntityIdProp = null,
   onSelectedEntityIdChange,
 }) => {
@@ -310,6 +312,17 @@ const MapView = ({
         }),
       );
       v.scene.globe.show = true;
+      /**
+       * Cesium fades day/night shading out when the camera is “close” to Earth (between
+       * lightingFadeOutDistance and lightingFadeInDistance measured from the origin). Default
+       * values (~10–20 Mm) sit above our typical strategic camera (~6.4 Mm radius + ~2.5 Mm
+       * height), so fade stays 0 and Blue Marble stays uniformly bright. Pull the band down so
+       * Lambert shading vs the sun is always on; the texture stays fixed to the ellipsoid while
+       * the terminator moves as `viewer.clock` tracks sim UTC.
+       */
+      v.scene.globe.lightingFadeOutDistance = 0;
+      v.scene.globe.lightingFadeInDistance = 1;
+      v.scene.globe.dynamicAtmosphereLightingFromSun = true;
 
       const [lat0, lon0] = mapBootstrap.center;
       v.camera.setView({
@@ -343,6 +356,34 @@ const MapView = ({
     canvas.addEventListener('contextmenu', onCtx);
     return () => canvas.removeEventListener('contextmenu', onCtx);
   }, [viewer]);
+
+  /** Tie Cesium time to simulation UTC so sun direction moves with exercise clock (globe “revolves” vs sunlight). */
+  useEffect(() => {
+    if (!viewer) return;
+    const iso = simTiming?.sim_time_utc;
+    if (typeof iso === 'string' && iso.length > 0) {
+      try {
+        const jd = Cesium.JulianDate.fromIso8601(iso);
+        if (Cesium.defined(jd)) {
+          viewer.clock.currentTime = jd;
+        }
+      } catch {
+        /* ignore malformed server timestamps */
+      }
+    }
+    viewer.scene.globe.enableLighting = true;
+    viewer.scene.globe.lightingFadeOutDistance = 0;
+    viewer.scene.globe.lightingFadeInDistance = 1;
+    viewer.scene.globe.dynamicAtmosphereLightingFromSun = true;
+    if (viewer.scene.sun) {
+      viewer.scene.sun.show = true;
+    }
+    try {
+      viewer.scene.requestRender?.();
+    } catch {
+      /* viewer torn down */
+    }
+  }, [viewer, simTiming?.sim_time_utc]);
 
   useEffect(() => {
     if (!viewer || !outerRef.current) return undefined;
@@ -770,7 +811,11 @@ const MapView = ({
     }
   }, [entities]);
 
-  /** Authoritative planned path from the server (`display_path_deg`); cyan polyline. */
+  /**
+   * Selection overlays from the server:
+   * - `display_path_deg`: planned movement (cyan).
+   * - `space.ground_track_deg`: subsatellite track ahead in sim time (amber, geodesic on ellipsoid).
+   */
   useEffect(() => {
     if (!viewer) return;
 
@@ -778,7 +823,12 @@ const MapView = ({
       const toRemove = [];
       viewer.entities.values.forEach((e) => {
         const id = e.id != null ? String(e.id) : '';
-        if (id.startsWith('overlay-auth-path-')) toRemove.push(e);
+        if (
+          id.startsWith('overlay-auth-path-') ||
+          id.startsWith('overlay-sat-ground-track-')
+        ) {
+          toRemove.push(e);
+        }
       });
       toRemove.forEach((e) => viewer.entities.remove(e));
     };
@@ -795,8 +845,7 @@ const MapView = ({
     }
 
     const row = entities.find((e) => e.id === selectedEntityId);
-    const path = row?.display_path_deg;
-    if (!row || !path || path.length < 2) {
+    if (!row) {
       try {
         viewer.scene.requestRender?.();
       } catch {
@@ -805,21 +854,40 @@ const MapView = ({
       return;
     }
 
-    const haeM = haeFeetToMeters(row.hae_ft);
-    const h = Number.isFinite(haeM) ? haeM : 0;
-    const flat = [];
-    for (const p of path) {
-      flat.push(p.lon_deg, p.lat_deg, h);
+    const movementPath = row.display_path_deg;
+    if (movementPath && movementPath.length >= 2) {
+      const haeM = haeFeetToMeters(row.hae_ft);
+      const h = Number.isFinite(haeM) ? haeM : 0;
+      const flat = [];
+      for (const p of movementPath) {
+        flat.push(p.lon_deg, p.lat_deg, h);
+      }
+      viewer.entities.add({
+        id: `overlay-auth-path-${selectedEntityId}`,
+        polyline: {
+          positions: Cesium.Cartesian3.fromDegreesArrayHeights(flat),
+          width: 4,
+          material: Cesium.Color.CYAN.withAlpha(0.88),
+        },
+      });
     }
 
-    viewer.entities.add({
-      id: `overlay-auth-path-${selectedEntityId}`,
-      polyline: {
-        positions: Cesium.Cartesian3.fromDegreesArrayHeights(flat),
-        width: 4,
-        material: Cesium.Color.CYAN.withAlpha(0.88),
-      },
-    });
+    const groundTrack = row.space?.ground_track_deg;
+    if (groundTrack && groundTrack.length >= 2) {
+      const flatGround = [];
+      for (const p of groundTrack) {
+        flatGround.push(p.lon_deg, p.lat_deg, 0);
+      }
+      viewer.entities.add({
+        id: `overlay-sat-ground-track-${selectedEntityId}`,
+        polyline: {
+          positions: Cesium.Cartesian3.fromDegreesArrayHeights(flatGround),
+          width: 3,
+          material: Cesium.Color.fromCssColorString('#f59e0b').withAlpha(0.9),
+          arcType: Cesium.ArcType.GEODESIC,
+        },
+      });
+    }
 
     try {
       viewer.scene.requestRender?.();

--- a/server/src/earth.rs
+++ b/server/src/earth.rs
@@ -2,6 +2,16 @@
 //!
 //! Used for entity motion, orbit station-keeping distances, and any server-side
 //! range/bearing checks. See `docs/EARTH_AND_TERRAIN.md` for terrain / DTED plans.
+//!
+//! ## Simulation frames (terrestrial rotation)
+//!
+//! **Surface and air** units use **Earth-fixed** WGS84 geodetic (`lat_deg`, `lon_deg`, HAE): a
+//! stationary asset keeps constant coordinates on the rotating body (it “sticks” to the globe).
+//!
+//! **Satellites** are propagated in **TEME/ECI** by SGP4, then converted to Earth-fixed geodetic
+//! using **GMST** in [`crate::space`]. Subsatellite latitude/longitude, footprints, and
+//! satellite–ground geometry (FoV caps, horizon distance) are therefore all evaluated in the same
+//! rotating frame, consistent with line-of-sight and coverage over a spinning Earth.
 
 use geographiclib_rs::{Geodesic, DirectGeodesic, InverseGeodesic};
 use std::sync::OnceLock;
@@ -15,6 +25,11 @@ fn wgs84() -> &'static Geodesic {
 
 /// WGS84 semi-major axis (m).
 pub const WGS84_A_M: f64 = 6378137.0;
+
+/// Conventional angular velocity of Earth about its axis (rad/s), WGS84 / IERS-style nominal.
+/// Documented for physics and any future inertial↔Earth-fixed conversions; terrestrial entity
+/// coordinates in this sim stay Earth-fixed and are **not** drifted by this rate each tick.
+pub const EARTH_SIDEREAL_ROTATION_RATE_RAD_PER_S: f64 = 7.2921151467e-5;
 
 /// International foot in meters (exact definition). Used to convert WGS84 HAE between ft (wire format) and m (physics / Cesium).
 ///
@@ -365,5 +380,11 @@ mod tests {
         let (lat1, lon1) = geodesic_direct_deg(lat0, lon0, hdg, dist);
         let back = geodesic_distance_m(lat0, lon0, lat1, lon1);
         assert!((back - dist).abs() < 0.5, "back={} dist={}", back, dist);
+    }
+
+    #[test]
+    fn earth_sidereal_rate_matches_sidereal_day_length() {
+        let period_s = std::f64::consts::TAU / EARTH_SIDEREAL_ROTATION_RATE_RAD_PER_S;
+        assert!((period_s - 86164.0905).abs() < 0.1, "period_s={}", period_s);
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -380,6 +380,7 @@ fn on_session_closed_stub(_public: &SessionPublic) {
     // Intentionally left empty for now.
 }
 
+/// Earth-fixed subsatellite point + footprint radius per satellite (after `propagate_space_entities`).
 fn collect_satellite_rows(world: &[EntityState]) -> Vec<(String, f64, f64, f64)> {
     world
         .iter()
@@ -398,6 +399,7 @@ fn collect_satellite_rows(world: &[EntityState]) -> Vec<(String, f64, f64, f64)>
         .collect()
 }
 
+/// Earth-fixed surface/air positions (no `space` component) for satellite coverage / LOS caps.
 fn collect_ground_rows(world: &[EntityState]) -> Vec<(String, f64, f64)> {
     world
         .iter()
@@ -406,6 +408,7 @@ fn collect_ground_rows(world: &[EntityState]) -> Vec<(String, f64, f64)> {
         .collect()
 }
 
+/// SGP4 + GMST: updates orbital transforms to Earth-fixed geodetic (independent of surface integration).
 fn propagate_space_entities(world: &mut [EntityState], t: DateTime<Utc>) {
     for e in world.iter_mut() {
         let Some(ref sp) = e.space else {
@@ -502,6 +505,8 @@ fn entity_snapshots_from_world(guard: &[EntityState]) -> Vec<EntitySnapshotDto> 
 }
 
 /// Integrate simple kinematics for `dt_sim_s` (simulated seconds, not wall time).
+/// Non-space units stay in **Earth-fixed** WGS84; coordinates are not advanced by sidereal rotation
+/// each tick (that rotation is implicit in the frame). Orbital states are updated separately.
 fn integrate_entities(world: &mut [EntityState], dt_sim_s: f64) {
     for entity in world.iter_mut() {
         if entity.attached_to_id.is_some() {

--- a/server/src/space.rs
+++ b/server/src/space.rs
@@ -1,6 +1,12 @@
 //! TLE / SGP4 propagation and satellite footprint geometry (space assets).
 //!
 //! Position uses the same ECI→geodetic path as `satellite.js` (`eciToGeodetic` + `gstime`).
+//!
+//! **Earth rotation:** SGP4 yields an inertial (TEME) state; [`propagate_lat_lon_hae`] applies
+//! Greenwich sidereal time so latitude/longitude are **Earth-fixed** (co-rotating with the globe).
+//! Coverage and LOS-style caps ([`ground_point_in_fov`], [`ground_visibility_cap_radius_m`]) compare
+//! those subsatellite/footprint quantities to terrestrial entities expressed in the same WGS84
+//! Earth-fixed frame (see [`crate::earth`] module docs).
 
 use chrono::{DateTime, Datelike, TimeZone, Timelike, Utc};
 use sgp4::{Constants, Elements};
@@ -282,7 +288,8 @@ pub fn current_coverage_pairs(
     next
 }
 
-/// Whether `ground` (lat/lon, surface) lies inside the satellite nadir footprint (geodesic cap).
+/// Whether `ground` (lat/lon, Earth-fixed surface) lies inside the satellite nadir footprint
+/// (geodesic cap). Satellite arguments must be Earth-fixed subsatellite point for the same instant.
 pub fn ground_point_in_fov(
     sub_lat_deg: f64,
     sub_lon_deg: f64,


### PR DESCRIPTION
## Summary
This PR improves how the map reflects simulation time relative to the sun, documents Earth-fixed vs orbital frames on the server, and shows predicted subsatellite tracks for selected satellites.

## Server
- Expand `earth` / `space` / `main` documentation: terrestrial entities use Earth-fixed WGS84; SGP4 + GMST yields Earth-fixed subsatellite geometry for coverage and tracks.
- Add `EARTH_SIDEREAL_ROTATION_RATE_RAD_PER_S` and a test tying it to sidereal day length.

## Client (MapView)
- Pass `simTiming` from App; set Cesium `clock.currentTime` from `sim_time_utc`.
- Enable globe lighting and sun; set `lightingFadeOutDistance` / `lightingFadeInDistance` so day/night shading applies at strategic camera heights (Cesium defaults were fading shading out entirely).
- `dynamicAtmosphereLightingFromSun` for sun-aligned atmosphere lighting.
- When a space unit is selected, draw `space.ground_track_deg` as an amber geodesic polyline (server already samples ~30 min ahead).

## Testing
- `docker compose --profile tests run --rm server-test` (cargo test) recommended.

Made with [Cursor](https://cursor.com)