### PR TITLE
fix(map): reduce Cesium flicker; narrow CI triggers

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,9 +2,9 @@
 name: E2E (Cypress)
 
 on:
-  push:
-    branches: ['**']
   pull_request:
+    branches: [main]
+  push:
     branches: [main]
 
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,11 @@
 name: Tests (Docker)
 
 on:
-  # All branch pushes (feature branches get CI before a PR exists).
-  push:
-    branches: ['**']
+  # PRs targeting main (open + each push to the PR branch). Not on every feature-branch push.
   pull_request:
+    branches: [main]
+  # Merges / direct pushes to main still get a check.
+  push:
     branches: [main]
 
 concurrency:

--- a/client/src/components/MapView.jsx
+++ b/client/src/components/MapView.jsx
@@ -91,6 +91,35 @@ function isGlobeUnitSelected(entity, selectedEntityId) {
   return selectedEntityId != null && String(entity.id) === String(selectedEntityId);
 }
 
+/** Cache key for milsymbol raster (skip SVG→dataURL work when unchanged between snapshots). */
+function milsymbolRasterKey(entity, selected) {
+  return `${normalizeSidc(entity.sidc)}|${selected ? 1 : 0}|${Number(entity.heading_deg ?? 0).toFixed(2)}`;
+}
+
+/** Add or update a polyline overlay without remove+add each tick (avoids flicker). */
+function setOrUpdatePolylineOverlay(entityCollection, id, flatLonLatHeight, polylineOpts) {
+  const positions = Cesium.Cartesian3.fromDegreesArrayHeights(flatLonLatHeight);
+  const ent = entityCollection.getById(id);
+  if (!Cesium.defined(ent)) {
+    entityCollection.add({
+      id,
+      polyline: {
+        positions,
+        ...polylineOpts,
+      },
+    });
+    return;
+  }
+  if (!ent.polyline) {
+    ent.polyline = new Cesium.PolylineGraphics({
+      positions,
+      ...polylineOpts,
+    });
+  } else {
+    ent.polyline.positions = new Cesium.ConstantProperty(positions);
+  }
+}
+
 function isTypingInFormField() {
   const el = document.activeElement;
   if (!el || typeof el !== 'object') return false;
@@ -198,6 +227,8 @@ const MapView = ({
   /** Set when Cesium.Viewer fails (e.g. WebGL); keeps tab chrome usable. */
   const [viewerInitError, setViewerInitError] = useState(null);
   const deferredFocusAppliedRef = useRef(false);
+  /** Per-entity milsymbol raster cache; avoids regenerating SVG/data URLs every snapshot. */
+  const milsymbolRasterCacheRef = useRef(new Map());
 
   useEffect(() => {
     planWaypointsRef.current = planWaypoints;
@@ -626,24 +657,37 @@ const MapView = ({
       } else if (imagePath) {
         const uri = publicAssetUrl(imagePath);
         const edge = selected ? 52 : 40;
-        const billboardOpts = {
-          image: uri,
-          width: edge,
-          height: edge,
-          scale: selected ? 1.08 : 1.0,
-          verticalOrigin: Cesium.VerticalOrigin.CENTER,
-          horizontalOrigin: Cesium.HorizontalOrigin.CENTER,
-        };
         if (Cesium.defined(existing)) {
           existing.position = new Cesium.ConstantPositionProperty(position);
           existing.orientation = undefined;
-          stripUnitMarkerPrimitives(existing);
-          existing.billboard = new Cesium.BillboardGraphics(billboardOpts);
+          if (existing.billboard) {
+            existing.billboard.image = new Cesium.ConstantProperty(uri);
+            existing.billboard.width = new Cesium.ConstantProperty(edge);
+            existing.billboard.height = new Cesium.ConstantProperty(edge);
+            existing.billboard.scale = new Cesium.ConstantProperty(selected ? 1.08 : 1.0);
+          } else {
+            stripUnitMarkerPrimitives(existing);
+            existing.billboard = new Cesium.BillboardGraphics({
+              image: uri,
+              width: edge,
+              height: edge,
+              scale: selected ? 1.08 : 1.0,
+              verticalOrigin: Cesium.VerticalOrigin.CENTER,
+              horizontalOrigin: Cesium.HorizontalOrigin.CENTER,
+            });
+          }
         } else {
           viewer.entities.add({
             id: uid,
             position,
-            billboard: billboardOpts,
+            billboard: {
+              image: uri,
+              width: edge,
+              height: edge,
+              scale: selected ? 1.08 : 1.0,
+              verticalOrigin: Cesium.VerticalOrigin.CENTER,
+              horizontalOrigin: Cesium.HorizontalOrigin.CENTER,
+            },
           });
         }
       } else if (wantsCesiumShape) {
@@ -685,8 +729,15 @@ const MapView = ({
           if (Cesium.defined(existing)) {
             existing.position = new Cesium.ConstantPositionProperty(position);
             existing.orientation = undefined;
-            stripUnitMarkerPrimitives(existing);
-            existing.point = new Cesium.PointGraphics(pt);
+            if (existing.point) {
+              existing.point.pixelSize = new Cesium.ConstantProperty(pixelSize);
+              existing.point.color = new Cesium.ConstantProperty(mat);
+              existing.point.outlineColor = new Cesium.ConstantProperty(outlineCol);
+              existing.point.outlineWidth = new Cesium.ConstantProperty(1);
+            } else {
+              stripUnitMarkerPrimitives(existing);
+              existing.point = new Cesium.PointGraphics(pt);
+            }
           } else {
             viewer.entities.add({
               id: uid,
@@ -737,29 +788,37 @@ const MapView = ({
           addOrUpdateShape({ cylinder: cyl }, 'cylinder');
         }
       } else {
-        let image;
-        let width = 32;
-        let height = 32;
-
-        try {
-          const normalizedSidc = normalizeSidc(entity.sidc);
-          const symbol = new ms.Symbol(normalizedSidc, {
-            size: selected ? 36 : 28,
-            standard: MILSYMBOL_STANDARD,
-            direction: Number(entity.heading_deg ?? 0),
-            outlineWidth: selected ? 6 : 0,
-            outlineColor: selected ? '#fbbf24' : 'rgb(239, 239, 239)',
-          });
-          image = svgToImageDataUrl(symbol.asSVG());
-          const maxEdge = selected ? 42 : 34;
-          const wh = billboardPixelSizeFromMilsymbol(symbol, maxEdge);
-          width = wh.width;
-          height = wh.height;
-        } catch {
-          image = svgToImageDataUrl(
-            '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><circle cx="16" cy="16" r="10" fill="#0f4c81" stroke="#fff" stroke-width="2"/></svg>',
-          );
+        const visKey = milsymbolRasterKey(entity, selected);
+        const cache = milsymbolRasterCacheRef.current;
+        let cached = cache.get(entity.id);
+        let rasterDirty = !cached || cached.key !== visKey;
+        if (rasterDirty) {
+          let image;
+          let width = 32;
+          let height = 32;
+          try {
+            const normalizedSidc = normalizeSidc(entity.sidc);
+            const symbol = new ms.Symbol(normalizedSidc, {
+              size: selected ? 36 : 28,
+              standard: MILSYMBOL_STANDARD,
+              direction: Number(entity.heading_deg ?? 0),
+              outlineWidth: selected ? 6 : 0,
+              outlineColor: selected ? '#fbbf24' : 'rgb(239, 239, 239)',
+            });
+            image = svgToImageDataUrl(symbol.asSVG());
+            const maxEdge = selected ? 42 : 34;
+            const wh = billboardPixelSizeFromMilsymbol(symbol, maxEdge);
+            width = wh.width;
+            height = wh.height;
+          } catch {
+            image = svgToImageDataUrl(
+              '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><circle cx="16" cy="16" r="10" fill="#0f4c81" stroke="#fff" stroke-width="2"/></svg>',
+            );
+          }
+          cached = { key: visKey, image, width, height };
+          cache.set(entity.id, cached);
         }
+        const { image, width, height } = cached;
 
         const billboardOpts = {
           image,
@@ -773,8 +832,17 @@ const MapView = ({
         if (Cesium.defined(existing)) {
           existing.position = new Cesium.ConstantPositionProperty(position);
           existing.orientation = undefined;
-          stripUnitMarkerPrimitives(existing);
-          existing.billboard = new Cesium.BillboardGraphics(billboardOpts);
+          if (existing.billboard) {
+            if (rasterDirty) {
+              existing.billboard.image = new Cesium.ConstantProperty(image);
+              existing.billboard.width = new Cesium.ConstantProperty(width);
+              existing.billboard.height = new Cesium.ConstantProperty(height);
+            }
+            existing.billboard.scale = new Cesium.ConstantProperty(selected ? 1.12 : 1.0);
+          } else {
+            stripUnitMarkerPrimitives(existing);
+            existing.billboard = new Cesium.BillboardGraphics(billboardOpts);
+          }
         } else {
           viewer.entities.add({
             id: uid,
@@ -782,6 +850,13 @@ const MapView = ({
             billboard: billboardOpts,
           });
         }
+      }
+    }
+
+    const stillPresent = new Set(entities.map((e) => e.id));
+    for (const id of milsymbolRasterCacheRef.current.keys()) {
+      if (!stillPresent.has(id)) {
+        milsymbolRasterCacheRef.current.delete(id);
       }
     }
 
@@ -819,21 +894,30 @@ const MapView = ({
   useEffect(() => {
     if (!viewer) return;
 
-    const stripPrev = () => {
-      const toRemove = [];
-      viewer.entities.values.forEach((e) => {
-        const id = e.id != null ? String(e.id) : '';
-        if (
-          id.startsWith('overlay-auth-path-') ||
-          id.startsWith('overlay-sat-ground-track-')
-        ) {
-          toRemove.push(e);
+    const wanted = new Set();
+    if (selectedEntityId) {
+      const row = entities.find((e) => e.id === selectedEntityId);
+      if (row) {
+        if (row.display_path_deg && row.display_path_deg.length >= 2) {
+          wanted.add(`overlay-auth-path-${selectedEntityId}`);
         }
-      });
-      toRemove.forEach((e) => viewer.entities.remove(e));
-    };
+        if (row.space?.ground_track_deg && row.space.ground_track_deg.length >= 2) {
+          wanted.add(`overlay-sat-ground-track-${selectedEntityId}`);
+        }
+      }
+    }
 
-    stripPrev();
+    const toRemove = [];
+    viewer.entities.values.forEach((e) => {
+      const id = e.id != null ? String(e.id) : '';
+      if (
+        (id.startsWith('overlay-auth-path-') || id.startsWith('overlay-sat-ground-track-')) &&
+        !wanted.has(id)
+      ) {
+        toRemove.push(e);
+      }
+    });
+    toRemove.forEach((e) => viewer.entities.remove(e));
 
     if (!selectedEntityId) {
       try {
@@ -862,13 +946,9 @@ const MapView = ({
       for (const p of movementPath) {
         flat.push(p.lon_deg, p.lat_deg, h);
       }
-      viewer.entities.add({
-        id: `overlay-auth-path-${selectedEntityId}`,
-        polyline: {
-          positions: Cesium.Cartesian3.fromDegreesArrayHeights(flat),
-          width: 4,
-          material: Cesium.Color.CYAN.withAlpha(0.88),
-        },
+      setOrUpdatePolylineOverlay(viewer.entities, `overlay-auth-path-${selectedEntityId}`, flat, {
+        width: 4,
+        material: Cesium.Color.CYAN.withAlpha(0.88),
       });
     }
 
@@ -878,15 +958,16 @@ const MapView = ({
       for (const p of groundTrack) {
         flatGround.push(p.lon_deg, p.lat_deg, 0);
       }
-      viewer.entities.add({
-        id: `overlay-sat-ground-track-${selectedEntityId}`,
-        polyline: {
-          positions: Cesium.Cartesian3.fromDegreesArrayHeights(flatGround),
+      setOrUpdatePolylineOverlay(
+        viewer.entities,
+        `overlay-sat-ground-track-${selectedEntityId}`,
+        flatGround,
+        {
           width: 3,
           material: Cesium.Color.fromCssColorString('#f59e0b').withAlpha(0.9),
           arcType: Cesium.ArcType.GEODESIC,
         },
-      });
+      );
     }
 
     try {

--- a/client/src/components/MapView.jsx
+++ b/client/src/components/MapView.jsx
@@ -91,9 +91,9 @@ function isGlobeUnitSelected(entity, selectedEntityId) {
   return selectedEntityId != null && String(entity.id) === String(selectedEntityId);
 }
 
-/** Cache key for milsymbol raster (skip SVG→dataURL work when unchanged between snapshots). */
+/** Cache key for milsymbol raster (skip SVG→dataURL work when unchanged between snapshots). Heading omitted so icons are not rebuilt when course changes. */
 function milsymbolRasterKey(entity, selected) {
-  return `${normalizeSidc(entity.sidc)}|${selected ? 1 : 0}|${Number(entity.heading_deg ?? 0).toFixed(2)}`;
+  return `${normalizeSidc(entity.sidc)}|${selected ? 1 : 0}`;
 }
 
 /** Add or update a polyline overlay without remove+add each tick (avoids flicker). */
@@ -801,7 +801,6 @@ const MapView = ({
             const symbol = new ms.Symbol(normalizedSidc, {
               size: selected ? 36 : 28,
               standard: MILSYMBOL_STANDARD,
-              direction: Number(entity.heading_deg ?? 0),
               outlineWidth: selected ? 6 : 0,
               outlineColor: selected ? '#fbbf24' : 'rgb(239, 239, 239)',
             });

--- a/client/src/components/MovementPlanningCesium.jsx
+++ b/client/src/components/MovementPlanningCesium.jsx
@@ -44,6 +44,142 @@ function removePreviewEntities(viewer) {
   toRemove.forEach((e) => viewer.entities.remove(e));
 }
 
+/** Avoid tearing down/recreating preview primitives every frame (world_snapshot gives new entity refs). */
+const PREVIEW_NO_DEPTH = Number.POSITIVE_INFINITY;
+
+function applyPreviewEntityDefaults(entity) {
+  if (Cesium.defined(entity)) {
+    entity.disableDepthTestDistance = PREVIEW_NO_DEPTH;
+  }
+}
+
+function cartesianArrayPositionsEqual(a, b, epsilon = 1e-5) {
+  if (!a || !b || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (!Cesium.Cartesian3.equalsEpsilon(a[i], b[i], epsilon)) return false;
+  }
+  return true;
+}
+
+/**
+ * Update or create a polyline; hide when `show` is false without removing (reduces flicker).
+ */
+function setOrUpdatePreviewPolyline(viewer, id, positions, show, polylineOpts) {
+  const ec = viewer.entities;
+  const ent = ec.getById(id);
+  if (!show || !positions) {
+    if (Cesium.defined(ent)) ent.show = false;
+    return;
+  }
+  if (!Cesium.defined(ent)) {
+    ec.add({
+      id,
+      disableDepthTestDistance: PREVIEW_NO_DEPTH,
+      polyline: {
+        positions,
+        arcType: Cesium.ArcType.GEODESIC,
+        ...polylineOpts,
+      },
+    });
+    return;
+  }
+  applyPreviewEntityDefaults(ent);
+  ent.show = true;
+  if (!ent.polyline) {
+    ent.polyline = new Cesium.PolylineGraphics({
+      positions,
+      arcType: Cesium.ArcType.GEODESIC,
+      ...polylineOpts,
+    });
+    return;
+  }
+  const t = viewer.clock?.currentTime ?? Cesium.JulianDate.now();
+  const prev = ent.polyline.positions?.getValue(t);
+  if (prev && cartesianArrayPositionsEqual(prev, positions)) {
+    return;
+  }
+  ent.polyline.positions = new Cesium.ConstantProperty(positions);
+}
+
+function syncPreviewWaypointMarkers(viewer, planWaypoints, planHaeM) {
+  const ec = viewer.entities;
+  const n = planWaypoints.length;
+  ec.values.forEach((e) => {
+    const sid = e.id != null ? String(e.id) : '';
+    const m = sid.match(/^preview-wp-(\d+)$/);
+    if (m && Number(m[1]) >= n) ec.remove(e);
+  });
+  const h = Number.isFinite(planHaeM) ? planHaeM : 0;
+  for (let i = 0; i < n; i++) {
+    const w = planWaypoints[i];
+    const pos = Cesium.Cartesian3.fromDegrees(w.lng, w.lat, h);
+    const id = `preview-wp-${i}`;
+    let ent = ec.getById(id);
+    if (!Cesium.defined(ent)) {
+      ec.add({
+        id,
+        position: pos,
+        disableDepthTestDistance: PREVIEW_NO_DEPTH,
+        point: new Cesium.PointGraphics({
+          pixelSize: greenWaypoint.pixelSize,
+          color: greenWaypoint.color,
+          outlineColor: greenWaypoint.outlineColor,
+          outlineWidth: greenWaypoint.outlineWidth,
+        }),
+      });
+    } else {
+      applyPreviewEntityDefaults(ent);
+      ent.position = new Cesium.ConstantPositionProperty(pos);
+      ent.show = true;
+      if (!ent.point) {
+        ent.point = new Cesium.PointGraphics({
+          pixelSize: greenWaypoint.pixelSize,
+          color: greenWaypoint.color,
+          outlineColor: greenWaypoint.outlineColor,
+          outlineWidth: greenWaypoint.outlineWidth,
+        });
+      }
+    }
+  }
+}
+
+function setOrUpdatePreviewEllipse(viewer, id, centerDeg, planHaeM, semiMajorM, semiMinorM, ellipseOpts) {
+  const ec = viewer.entities;
+  const ent = ec.getById(id);
+  const show = Boolean(centerDeg) && semiMajorM > 0 && semiMinorM > 0;
+  if (!show) {
+    if (Cesium.defined(ent)) ent.show = false;
+    return;
+  }
+  const pos = Cesium.Cartesian3.fromDegrees(centerDeg.lng, centerDeg.lat, planHaeM);
+  if (!Cesium.defined(ent)) {
+    ec.add({
+      id,
+      position: pos,
+      disableDepthTestDistance: PREVIEW_NO_DEPTH,
+      ellipse: new Cesium.EllipseGraphics({
+        semiMajorAxis: semiMajorM,
+        semiMinorAxis: semiMinorM,
+        ...ellipseOpts,
+      }),
+    });
+    return;
+  }
+  applyPreviewEntityDefaults(ent);
+  ent.show = true;
+  ent.position = new Cesium.ConstantPositionProperty(pos);
+  if (!ent.ellipse) {
+    ent.ellipse = new Cesium.EllipseGraphics({
+      semiMajorAxis: semiMajorM,
+      semiMinorAxis: semiMinorM,
+      ...ellipseOpts,
+    });
+  } else {
+    ent.ellipse.semiMajorAxis = new Cesium.ConstantProperty(semiMajorM);
+    ent.ellipse.semiMinorAxis = new Cesium.ConstantProperty(semiMinorM);
+  }
+}
+
 /** @param {[number, number][]} latLonPairs — [lat, lon]; @param haeM WGS84 height (m) for Cesium. */
 function llToPositionsWithHae(latLonPairs, haeM) {
   const h = Number.isFinite(haeM) ? haeM : 0;
@@ -80,6 +216,7 @@ const MovementPlanningCesium = forwardRef(function MovementPlanningCesium(
   const lastEdgeRef = useRef(null);
   const planWaypointsRef = useRef(planWaypoints);
   const racetrackRef = useRef(racetrackDraft);
+  const viewerRef = useRef(null);
   const [orbitPreview, setOrbitPreview] = useState(null);
   const [racetrackRadiusPreview, setRacetrackRadiusPreview] = useState(null);
   const originalCameraControllerFlagsRef = useRef(null);
@@ -87,6 +224,13 @@ const MovementPlanningCesium = forwardRef(function MovementPlanningCesium(
   const rightMouseDownRef = useRef(false);
   /** Pointer id when O/R station planning captured the canvas (so pointerup fires reliably after drag). */
   const stationPointerIdRef = useRef(null);
+
+  /** Snapshot geometry only — avoids preview effect re-running every tick when `selectedEntity` is a new object ref from world_snapshot. */
+  const selId = selectedEntity?.id ?? null;
+  const selLat = selectedEntity?.lat_deg;
+  const selLon = selectedEntity?.lon_deg;
+  const selHaeFt = selectedEntity?.hae_ft;
+  const selHeadingDeg = selectedEntity?.heading_deg ?? 0;
 
   useImperativeHandle(
     ref,
@@ -112,6 +256,23 @@ const MovementPlanningCesium = forwardRef(function MovementPlanningCesium(
   useEffect(() => {
     racetrackRef.current = racetrackDraft;
   }, [racetrackDraft]);
+  useEffect(() => {
+    viewerRef.current = viewer;
+  }, [viewer]);
+
+  useEffect(
+    () => () => {
+      const v = viewerRef.current;
+      if (v) {
+        try {
+          removePreviewEntities(v);
+        } catch {
+          /* viewer may be destroyed */
+        }
+      }
+    },
+    [],
+  );
 
   const canPlan = Boolean(sessionId && socket && selectedEntity?.id && selectedEntity?.movable);
   const stationModifierActive = (oHeld && !rHeld) || (rHeld && !oHeld);
@@ -511,44 +672,44 @@ const MovementPlanningCesium = forwardRef(function MovementPlanningCesium(
   ]);
 
   const pathPositions = useMemo(() => {
-    if (!selectedEntity) return [];
-    const pts = [[selectedEntity.lat_deg, selectedEntity.lon_deg]];
+    if (selId == null || selLat == null || selLon == null) return [];
+    const pts = [[selLat, selLon]];
     for (const w of planWaypoints) {
       pts.push([w.lat, w.lng]);
     }
     return pts;
-  }, [selectedEntity, planWaypoints]);
+  }, [selId, selLat, selLon, planWaypoints]);
 
   const orbitApproachSegment = useMemo(() => {
-    if (!orbitPreview?.center || !orbitPreview?.edge || !selectedEntity) return null;
+    if (!orbitPreview?.center || !orbitPreview?.edge || selId == null) return null;
+    if (selLat == null || selLon == null) return null;
     const lastLat =
       planWaypoints.length > 0
         ? planWaypoints[planWaypoints.length - 1].lat
-        : selectedEntity.lat_deg;
+        : selLat;
     const lastLon =
       planWaypoints.length > 0
         ? planWaypoints[planWaypoints.length - 1].lng
-        : selectedEntity.lon_deg;
+        : selLon;
     const r = geodesicDistanceM(
       orbitPreview.center.lat,
       orbitPreview.center.lng,
       orbitPreview.edge.lat,
       orbitPreview.edge.lng,
     );
-    const hdg = selectedEntity.heading_deg ?? 0;
     const join = geodesicPointTowardFromCenter(
       orbitPreview.center.lat,
       orbitPreview.center.lng,
       lastLat,
       lastLon,
       r,
-      hdg,
+      selHeadingDeg,
     );
     return [
       [lastLat, lastLon],
       [join.latDeg, join.lonDeg],
     ];
-  }, [orbitPreview, planWaypoints, selectedEntity]);
+  }, [orbitPreview, planWaypoints, selId, selLat, selLon, selHeadingDeg]);
 
   const racetrackLine = useMemo(
     () =>
@@ -563,56 +724,40 @@ const MovementPlanningCesium = forwardRef(function MovementPlanningCesium(
 
   useEffect(() => {
     if (!viewer) return;
-    removePreviewEntities(viewer);
-
-    const planHaeM = haeFeetToMeters(selectedEntity?.hae_ft);
-
-    for (let i = 0; i < planWaypoints.length; i++) {
-      const w = planWaypoints[i];
-      viewer.entities.add({
-        id: `preview-wp-${i}`,
-        position: Cesium.Cartesian3.fromDegrees(w.lng, w.lat, planHaeM),
-        point: {
-          pixelSize: greenWaypoint.pixelSize,
-          color: greenWaypoint.color,
-          outlineColor: greenWaypoint.outlineColor,
-          outlineWidth: greenWaypoint.outlineWidth,
-        },
-      });
+    if (selId == null) {
+      removePreviewEntities(viewer);
+      try {
+        viewer.scene.requestRender?.();
+      } catch {
+        /* ignore */
+      }
+      return;
     }
 
-    if (pathPositions.length >= 2) {
-      viewer.entities.add({
-        id: 'preview-path',
-        polyline: {
-          positions: llToPositionsWithHae(pathPositions, planHaeM),
-          width: 3,
-          material: greenLine.color,
-        },
-      });
-    }
+    const planHaeM = haeFeetToMeters(selHaeFt);
 
-    if (orbitApproachSegment) {
-      viewer.entities.add({
-        id: 'preview-orbit-approach',
-        polyline: {
-          positions: llToPositionsWithHae(orbitApproachSegment, planHaeM),
-          width: 2,
-          material: Cesium.Color.CYAN.withAlpha(0.7),
-        },
-      });
-    }
+    syncPreviewWaypointMarkers(viewer, planWaypoints, planHaeM);
 
-    if (racetrackLine) {
-      viewer.entities.add({
-        id: 'preview-racetrack-ab',
-        polyline: {
-          positions: llToPositionsWithHae(racetrackLine, planHaeM),
-          width: 2,
-          material: Cesium.Color.LIME.withAlpha(0.85),
-        },
-      });
-    }
+    const greenPathPositions =
+      pathPositions.length >= 2 ? llToPositionsWithHae(pathPositions, planHaeM) : null;
+    setOrUpdatePreviewPolyline(viewer, 'preview-path', greenPathPositions, Boolean(greenPathPositions), {
+      width: greenLine.width,
+      material: new Cesium.ColorMaterialProperty(greenLine.color),
+    });
+
+    const orbitSegPos = orbitApproachSegment
+      ? llToPositionsWithHae(orbitApproachSegment, planHaeM)
+      : null;
+    setOrUpdatePreviewPolyline(viewer, 'preview-orbit-approach', orbitSegPos, Boolean(orbitSegPos), {
+      width: 2,
+      material: new Cesium.ColorMaterialProperty(Cesium.Color.CYAN.withAlpha(0.7)),
+    });
+
+    const rtSegPos = racetrackLine ? llToPositionsWithHae(racetrackLine, planHaeM) : null;
+    setOrUpdatePreviewPolyline(viewer, 'preview-racetrack-ab', rtSegPos, Boolean(rtSegPos), {
+      width: 2,
+      material: new Cesium.ColorMaterialProperty(Cesium.Color.LIME.withAlpha(0.85)),
+    });
 
     if (orbitPreview?.center && orbitPreview?.edge) {
       const r = Math.max(
@@ -624,19 +769,16 @@ const MovementPlanningCesium = forwardRef(function MovementPlanningCesium(
         ),
         1,
       );
-      viewer.entities.add({
-        id: 'preview-orbit-circle',
-        position: Cesium.Cartesian3.fromDegrees(orbitPreview.center.lng, orbitPreview.center.lat, planHaeM),
-        ellipse: {
-          semiMajorAxis: r,
-          semiMinorAxis: r,
-          material: Cesium.Color.LIME.withAlpha(0.12),
-          outline: true,
-          outlineColor: Cesium.Color.LIME,
-          outlineWidth: 2,
-          height: 0,
-        },
+      setOrUpdatePreviewEllipse(viewer, 'preview-orbit-circle', orbitPreview.center, planHaeM, r, r, {
+        material: new Cesium.ColorMaterialProperty(Cesium.Color.LIME.withAlpha(0.12)),
+        outline: true,
+        outlineColor: Cesium.Color.LIME,
+        outlineWidth: 2,
+        height: 0,
       });
+    } else {
+      const oe = viewer.entities.getById('preview-orbit-circle');
+      if (Cesium.defined(oe)) oe.show = false;
     }
 
     if (racetrackRadiusPreview?.center && racetrackRadiusPreview?.edge) {
@@ -649,35 +791,38 @@ const MovementPlanningCesium = forwardRef(function MovementPlanningCesium(
         ),
         1,
       );
-      viewer.entities.add({
-        id: 'preview-racetrack-circle',
-        position: Cesium.Cartesian3.fromDegrees(
-          racetrackRadiusPreview.center.lng,
-          racetrackRadiusPreview.center.lat,
-          planHaeM,
-        ),
-        ellipse: {
-          semiMajorAxis: r,
-          semiMinorAxis: r,
-          material: Cesium.Color.MEDIUMSPRINGGREEN.withAlpha(0.1),
+      setOrUpdatePreviewEllipse(
+        viewer,
+        'preview-racetrack-circle',
+        racetrackRadiusPreview.center,
+        planHaeM,
+        r,
+        r,
+        {
+          material: new Cesium.ColorMaterialProperty(Cesium.Color.MEDIUMSPRINGGREEN.withAlpha(0.1)),
           outline: true,
           outlineColor: Cesium.Color.MEDIUMSPRINGGREEN,
           outlineWidth: 2,
           height: 0,
         },
-      });
+      );
+    } else {
+      const re = viewer.entities.getById('preview-racetrack-circle');
+      if (Cesium.defined(re)) re.show = false;
     }
 
-    return () => {
-      try {
-        removePreviewEntities(viewer);
-      } catch {
-        /* viewer may already be destroyed */
-      }
-    };
+    try {
+      viewer.scene.requestRender?.();
+    } catch {
+      /* ignore */
+    }
   }, [
     viewer,
-    selectedEntity,
+    selId,
+    selLat,
+    selLon,
+    selHaeFt,
+    selHeadingDeg,
     planWaypoints,
     pathPositions,
     orbitApproachSegment,


### PR DESCRIPTION
## Summary
- **MovementPlanningCesium**: Preview path/orbit/racetrack visuals use stable geometry fields (`selLat`/`selLon`/…) instead of whole `selectedEntity` refs so effects don’t re-run every `world_snapshot` when only the parsed object identity changes. In-place polyline updates and skip when Cartesian positions are unchanged.
- **MapView**: Milsymbol raster cache key no longer includes heading; removed `direction` from Symbol options so icons aren’t rebuilt every tick when heading changes.

## CI
- **Tests** and **E2E** workflows: run on `pull_request` to `main` and `push` to `main` only. **Removed** `push` on all branches (`**`**), so arbitrary feature-branch pushes without a PR no longer trigger CI.

## Notes
If you want CI to run **only** when a PR is first opened (and not on subsequent pushes to the PR), say so—we can tighten `pull_request` to `types: [opened]` (with the tradeoff that new commits on the PR would not run checks until merge).

Made with [Cursor](https://cursor.com)